### PR TITLE
Fix program icon not being saved when resource path contains spaces

### DIFF
--- a/src/pmgseg.c
+++ b/src/pmgseg.c
@@ -1522,6 +1522,7 @@ PITEM PASCAL CreateNewItem(
 		lstrcpy(szIconExe, lpCommand);
 	}
 	DoEnvironmentSubst(szIconExe, (WORD)CharSizeOf(szIconExe));
+	PathQuoteSpacesW(szIconExe);
 	StripArgs(szIconExe);
 	if (!bNoIconPath) {
 		TagExtension(szIconExe, sizeof(szIconExe));


### PR DESCRIPTION
Right now, if a resource path has spaces, the icon for a program reverts to the progman default.
Fixes https://github.com/freedom7341/Progman-x64/issues/1